### PR TITLE
quick fix Divmmc not start issue in classic videomode

### DIFF
--- a/firmware/src/fpga/profi/rtl/karabas_pro.vhd
+++ b/firmware/src/fpga/profi/rtl/karabas_pro.vhd
@@ -1173,7 +1173,7 @@ cpu_wait_n <= '1';
 -- max turbo = 14 MHz
 max_turbo <= "10";
 
-clk_cpu <= '0' when kb_wait = '1' or  (kb_screen_mode = "01" and memory_contention = '1' and DS80 = '0') or WAIT_IO = '0' else 
+clk_cpu <= '0' when kb_wait = '1' or  (kb_screen_mode = "01" and memory_contention = '1' and automap = '0' and DS80 = '0') or WAIT_IO = '0' else 
 	clk_bus when turbo_mode = "11" and turbo_mode <= max_turbo else 
 	clk_bus and ena_div2 when turbo_mode = "10" and turbo_mode <= max_turbo else 
 	clk_bus and ena_div4 when turbo_mode = "01" and turbo_mode <= max_turbo else 


### PR DESCRIPTION
stopping CPU clk cause error on DIVMMC io or mem operations (and maybe affect io or mem operations with other hardware, i don't lookd deeper)