### PR TITLE
fix uart and zifi in turbo mode x2 x4

### DIFF
--- a/firmware/src/fpga/profi/rtl/uart/zxunouart.v
+++ b/firmware/src/fpga/profi/rtl/uart/zxunouart.v
@@ -1,25 +1,27 @@
 `timescale 1ns / 1ps
 `default_nettype none
 
-//////////////////////////////////////////////////////////////////////////////////
-// Company: 
-// Engineer: 
-// 
-// Create Date:    23:26:34 10/17/2015 
-// Design Name: 
-// Module Name:    zxunouart 
-// Project Name: 
-// Target Devices: 
-// Tool versions: 
-// Description: 
+//    This file is part of the ZXUNO Spectrum core. 
+//    Creation date is 23:26:34 2015-10-17 by Miguel Angel Rodriguez Jodar
+//    (c)2014-2020 ZXUNO association.
+//    ZXUNO official repository: http://svn.zxuno.com/svn/zxuno
+//    Username: guest   Password: zxuno
+//    Github repository for this core: https://github.com/mcleod-ideafix/zxuno_spectrum_core
 //
-// Dependencies: 
+//    ZXUNO Spectrum core is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
 //
-// Revision: 
-// Revision 0.01 - File Created
-// Additional Comments: 
+//    ZXUNO Spectrum core is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
 //
-//////////////////////////////////////////////////////////////////////////////////
+//    You should have received a copy of the GNU General Public License
+//    along with the ZXUNO Spectrum core.  If not, see <https://www.gnu.org/licenses/>.
+//
+//    Any distributed copy of this file must keep this notice intact.
 
 module zxunouart (
     input wire clk_bus,
@@ -37,18 +39,18 @@ module zxunouart (
 
     parameter UARTDATA = 8'hC6;
     parameter UARTSTAT = 8'hC7;
-
+	 
+    parameter CLK = 28000000;
     wire txbusy;
     wire data_received;
     wire [7:0] rxdata;
-    
+
     reg comenzar_trans = 1'b0;
-    reg rxrecv = 1'b0;
     reg leyendo_estado = 1'b0;
- 
+
     wire data_read;
-    
-    uart uartchip (
+
+    uart #(.CLK(CLK)) uartchip (
         .clk_bus(clk_bus),
 		  .ds80(ds80),
         .txdata(din),
@@ -66,35 +68,23 @@ module zxunouart (
 
     always @* begin
         oe_n = 1'b1;
-        dout = 8'hZZ;
-        if (zxuno_addr == UARTDATA && zxuno_regrd == 1'b1) begin
+        dout = 8'hFF;
+        if (data_read) begin
             dout = rxdata;
             oe_n = 1'b0;
         end
         else if (zxuno_addr == UARTSTAT && zxuno_regrd == 1'b1) begin
-            dout = {rxrecv, txbusy, 6'h00};
+            dout = {data_received, txbusy, 6'h00};
             oe_n = 1'b0;
         end
     end
 
     always @(posedge clk_bus) begin
-		  if (zxuno_addr == UARTDATA && zxuno_regwr == 1'b1 && comenzar_trans == 1'b0 && txbusy == 1'b0) begin
-				comenzar_trans <= 1'b1;
-		  end
-		  if (comenzar_trans == 1'b1 && txbusy == 1'b1) begin
-				comenzar_trans <= 1'b0;
-		  end
-
-		  if (data_received == 1'b1)
-				rxrecv <= 1'b1;
-
-		  if (data_received == 1'b0) begin
-				if (zxuno_addr == UARTSTAT && zxuno_regrd == 1'b1)
-					 leyendo_estado <= 1'b1;
-				if (leyendo_estado == 1'b1 && (zxuno_addr != UARTSTAT || zxuno_regrd == 1'b0)) begin
-					 leyendo_estado <= 1'b0;
-					 rxrecv <= 1'b0;
-				end
-		  end
+        if (zxuno_addr == UARTDATA && zxuno_regwr == 1'b1 && comenzar_trans == 1'b0 && txbusy == 1'b0) begin
+            comenzar_trans <= 1'b1;
+        end
+        if (comenzar_trans == 1'b1 && txbusy == 1'b1) begin
+            comenzar_trans <= 1'b0;
+        end
     end
 endmodule


### PR DESCRIPTION
The UART code was taken and adapted from the latest Spectrum ZXUNO kernel. The behavior of rts(cts) was corrected so that it (and the RX state machine) remain inactive until the Z80 reads an incoming byte. A minor fix was made to the Zifi code to avoid duplicate incoming bytes caused by the new UART code. It is now more stable and can work with any Z80 clock signal.